### PR TITLE
Enable demand(function(){.....}).throw() scenarios when ctx is necessary

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -605,7 +605,7 @@ exports.throw = function(constructor, expected) {
   if (arguments.length == 1) expected = constructor, constructor = null
 
   var ok, exception
-  try { this.actual.call(null) } catch (ex) { ok = true; exception = ex }
+  try { this.actual.call(this.actual) } catch (ex) { ok = true; exception = ex }
   if (ok && constructor) ok = exception instanceof constructor
   if (ok && arguments.length) ok = exceptionEql(exception, expected)
 


### PR DESCRIPTION
Examine the following scenario:

``` js
function MyClass() {
  this.variable = 'not initialized';
  function myFunction() {
    if (this.variable === 'not initialized') {
      throw new Error('Tried using uninitialized MyClass');
    }
  }
}

var myObject = new MyClass();
myObject.myFunction.must.throw(Error, /uninitialized/);
```

Clearly, the exception containing 'uninitialized' must be thrown, but instead I get different exception saying "null doesn't have 'variable' property". That is because `this.actual.call(null)` uses `null` as the context.

By passing `this.actual` as the context the fix enables the following testing syntax:

``` js
var myObject = new MyClass();
demand(function() { myObject.myFunction() }).must.throw(Error, /uninitialized/);
```
