### PR TITLE
Print actual exception stack trace on 'throw' assertion fail

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -622,7 +622,7 @@ exports.throw = function(constructor, expected) {
     var msgCallback = function closure() {
         var msg =
             "throw" +
-            (expected ? (" " + expected) : "") +
+            (expected ? (' "' + expected + '"') : "") +
             (stack ? (" but threw \n" + stack) : "");
         return function msgCallback() { return msg; }
     };

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -606,16 +606,24 @@ exports.match = function(expected) {
  * @param [expected]
  */
 exports.throw = function(constructor, expected) {
-  if (arguments.length == 1) expected = constructor, constructor = null
+    if (arguments.length == 1) expected = constructor, constructor = null
 
-  var ok, exception
-  try { this.actual.call(null) } catch (ex) { ok = true; exception = ex }
-  if (ok && constructor) ok = exception instanceof constructor
-  if (ok && arguments.length) ok = exceptionEql(exception, expected)
+    var ok, exception, stack
+    try {
+        this.actual.call(null)
+    } catch (ex) {
+        ok = true;
+        exception = ex;
+        stack = ex.stack;
+    }
+    if (ok && constructor) ok = exception instanceof constructor
+    if (ok && arguments.length) ok = exceptionEql(exception, expected)
 
-  var demands = [ok, "throw"]
-  if (arguments.length) demands.push(expected)
-  insist.apply(this, demands)
+    var msgCallback = function closure() {
+        var msg = "throw " + expected + " but threw \n" + exception.stack;
+        return function msgCallback() { return msg; }
+    };
+    insist.apply(this, [ok, msgCallback()])
 }
 
 function exceptionEql(actual, expected) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -614,13 +614,16 @@ exports.throw = function(constructor, expected) {
     } catch (ex) {
         ok = true;
         exception = ex;
-        stack = ex.stack;
+        stack = ex && ex.stack;
     }
     if (ok && constructor) ok = exception instanceof constructor
     if (ok && arguments.length) ok = exceptionEql(exception, expected)
 
     var msgCallback = function closure() {
-        var msg = "throw " + expected + " but threw \n" + exception.stack;
+        var msg =
+            "throw" +
+            (expected ? (" " + expected) : "") +
+            (stack ? (" but threw \n" + stack) : "");
         return function msgCallback() { return msg; }
     };
     insist.apply(this, [ok, msgCallback()])

--- a/test/assertions_test.js
+++ b/test/assertions_test.js
@@ -1959,7 +1959,6 @@ describe("Must.prototype.throw", function() {
     var thrower = function() { throw "Nope!" }
     mustThrowAssertionError(function() { thrower.must.throw("Oh no!") }, {
       actual: thrower,
-      expected: "Oh no!",
       message: "function () { throw \"Nope!\" } must throw \"Oh no!\""
     })
   })


### PR DESCRIPTION
In my dev environment the console output looks just perfect. See below.

```
AssertionError: function () { [native code] } must throw /_types/ but threw
Error: use valid cql types while declaring columns in TABLE
Error
at FluentCql.setError (C:\code\fcql\lib\fluent-cql.js:63:43)
at FluentCql._columns (C:\code\fcql\lib\fluent-cql.js:388:25)
at FluentCql._table (C:\code\fcql\lib\fluent-cql.js:360:81)
at FluentCql.table (C:\code\fcql\lib\fluent-cql.js:343:38)
at C:\code\fcql\lib\builder.js:17:29
at ...
```