### PR TITLE
Fix for undefined Error.captureStackTrace.

### DIFF
--- a/lib/assertion_error.js
+++ b/lib/assertion_error.js
@@ -45,7 +45,8 @@ function AssertionError(msg, opts) {
    *
    * @property stack
    */
-  Error.captureStackTrace(this, opts && opts.caller || arguments.callee.caller)
+  var caller = opts && opts.caller || arguments.callee.caller
+  if (Error.captureStackTrace) Error.captureStackTrace(this, caller)
 }
 
 AssertionError.prototype = Object.create(Error.prototype, {


### PR DESCRIPTION
`Error.captureStackTrace` is a v8 extension, in other browsers (Firefox, PhantomJS...) failed assertion yields exception with message like `Error.captureStackTrace is not a function`.
