### PR TITLE
Add Must.prototype.permutationOf

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -559,6 +559,40 @@ exports.include = function(expected) {
 exports.contain = exports.include
 
 /**
+ * Assert the array is a permutation of another array.
+ *
+ * This mean the array must have all of the expected members,
+ * any duplicated items must be duplicated too.
+ *
+ * Members are compared using strict equal.
+ *
+ * @example
+ * [1, 1, 2, 3].must.be.a.permutationOf([3, 2, 1, 1]) // pass
+ * [1, 1, 2, 3].must.be.a.permutationOf([3, 2, 1]) // fail
+ * [1, 2, 3].must.be.a.permutationOf([2,3]) // fail
+ *
+ * @method members
+ * @param expected
+ */
+exports.permutationOf = function(expected) {
+  var result = isPermutationOf(this.actual, expected)
+
+  insist.call(this, result, "be a permutation of", expected, { diffable: true })
+}
+
+function isPermutationOf(actual, expected) {
+  if (!Array.isArray(actual) || !Array.isArray(expected)) return false
+  if (actual.length !== expected.length) return false
+
+  actual = actual.slice().sort()
+  expected = expected.slice().sort()
+  for (var i = 0; i < actual.length; i++) {
+    if (actual[i] !== expected[i]) return false
+  }
+  return true
+}
+
+/**
  * Assert object matches the given regular expression.
  *
  * If you pass in a non regular expression object, it'll be converted to one

--- a/test/assertions_test.js
+++ b/test/assertions_test.js
@@ -1684,6 +1684,50 @@ describe("Must.prototype.contain", function() {
   })
 })
 
+describe("Must.prototype.permutationOf", function() {
+  it("must pass if given array have same members", function() {
+    assertPass(function() { [1, 2, 3].must.be.a.permutationOf([3, 2, 1]) })
+  })
+
+  it("must fail if given array does not have same members", function() {
+    assertFail(function() { [1, 2, 3].must.be.a.permutationOf([1]) })
+  })
+
+  it("must fail if given array is missing duplicated members", function() {
+    assertFail(function() { [1, 2].must.be.a.permutationOf([2, 1, 1]) })
+  })
+
+  it("must fail if given array have extra duplicated members", function() {
+    assertFail(function() { [1, 1, 2].must.be.a.permutationOf([2, 1]) })
+  })
+
+  it("must pass if given array have same duplicated members", function() {
+    assertPass(function() { [1, 1, 2].must.be.a.permutationOf([2, 1, 1]) })
+  })
+
+  mustThrowAssertionError(function() { [1, 2, 3].must.be.a.permutationOf([1, 2]) }, {
+    actual: [1, 2, 3],
+    expected: [1, 2],
+    diffable: true,
+    message: "[1,2,3] must be a permutation of [1,2]"
+  })
+
+  describe(".not", function() {
+    function not() { [1, 2, 3].must.not.be.a.permutationOf([1, 2, 3]) }
+
+    it("must invert the assertion", function() {
+      assertFail(not)
+    })
+
+    mustThrowAssertionError(not, {
+      actual: [1, 2, 3],
+      expected: [1, 2, 3],
+      diffable: true,
+      message: "[1,2,3] must not be a permutation of [1,2,3]"
+    })
+  })
+})
+
 describe("Must.prototype.match", function() {
   describe("given String and RegExp", function() {
     var literal = "Year 2014 might be like 1984."


### PR DESCRIPTION
This is similar to `have members` from [chai](http://chaijs.com/api/bdd/#members). 

It would be nice to have `include members` or `is subset of` too, but that can be implemented in a different patch.
