### PR TITLE
Make `.throw()` check error instance

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -651,7 +651,7 @@ exports.throw = function(constructor, expected) {
 }
 
 function exceptionEql(actual, expected) {
-  if (expected == null) return actual === expected
+  if (expected == null || expected instanceof Error) return actual === expected
   // NOTE: The message in new Error(message) gets converted to a string.
   var msg = kindof(actual) == "string" ? actual : actual.message
 

--- a/test/assertions_test.js
+++ b/test/assertions_test.js
@@ -1825,6 +1825,21 @@ describe("Must.prototype.throw", function() {
     })
   })
 
+  describe("given Error instance", function() {
+    var instance = new Error("Sad face! :o(")
+
+    function thrower() { throw instance }
+    function otherThrower() { throw new Error("Sad face! :o(") }
+
+    it("must pass if function throws with identical error instance", function() {
+      assertPass(function() { thrower.must.throw(instance) })
+    })
+
+    it("must fail if function throws with a different error instance", function() {
+      assertFail(function() { otherThrower.must.throw(instance) })
+    })
+  })
+
   describe("given String", function() {
     function thrower() { throw new Error("Oh no!") }
     function stringThrower() { throw new Error("Oh no!") }


### PR DESCRIPTION
This adds support for the following assertion, which didn't work before.

``` javascript
var expect = require('must')
   , err   = new Error('Sad face! :o(')

expect(function() { throw instance }).to.throw(err)
```

Love your coding style btw!
