### PR TITLE
Adding .deepEqual() and .strictEqual()

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Must.js, please see the [Must.js API Documentation][api].
 - [boolean](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.boolean)()
 - [contain](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.contain)(expected)
 - [date](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.date)()
+- [deepEqual](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.deepEqual)(expected)
 - [empty](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.empty)()
 - [enumerable](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.enumerable)(property)
 - [enumerableProperty](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.enumerableProperty)(property)

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Must.js, please see the [Must.js API Documentation][api].
 - [permutationOf](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.permutationOf)(expected)
 - [property](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.property)(property, [value])
 - [regexp](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.regexp)()
+- [strictEqual](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.strictEqual)(expected)
 - [string](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.string)()
 - [throw](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.throw)([constructor], [expected])
 - [to](https://github.com/moll/js-must/blob/master/doc/API.md#Must.prototype.to)

--- a/doc/API.md
+++ b/doc/API.md
@@ -50,6 +50,7 @@ Must.js API Documentation
 - [permutationOf](#Must.prototype.permutationOf)(expected)
 - [property](#Must.prototype.property)(property, [value])
 - [regexp](#Must.prototype.regexp)()
+- [strictEqual](#Must.prototype.strictEqual)(expected)
 - [string](#Must.prototype.string)()
 - [throw](#Must.prototype.throw)([constructor], [expected])
 - [to](#Must.prototype.to)
@@ -631,6 +632,10 @@ Assert object is a regular expression.
 ```javascript
 /[a-z]/.must.be.a.regexp()
 ```
+
+<a name="Must.prototype.strictEqual" />
+### Must.prototype.strictEqual(expected)
+Alias of [`eql`](#Must.prototype.eql).
 
 <a name="Must.prototype.string" />
 ### Must.prototype.string()

--- a/doc/API.md
+++ b/doc/API.md
@@ -14,6 +14,7 @@ Must.js API Documentation
 - [boolean](#Must.prototype.boolean)()
 - [contain](#Must.prototype.contain)(expected)
 - [date](#Must.prototype.date)()
+- [deepEqual](#Must.prototype.deepEqual)(expected)
 - [empty](#Must.prototype.empty)()
 - [enumerable](#Must.prototype.enumerable)(property)
 - [enumerableProperty](#Must.prototype.enumerableProperty)(property)
@@ -232,6 +233,10 @@ Assert object is a date.
 ```javascript
 new Date().must.be.a.date()
 ```
+
+<a name="Must.prototype.deepEqual" />
+### Must.prototype.deepEqual(expected)
+Alias of [`equal`](#Must.prototype.equal).
 
 <a name="Must.prototype.empty" />
 ### Must.prototype.empty()

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -410,6 +410,12 @@ exports.equal = function(expected) {
 }
 
 /**
+ * @method strictEqual
+ * @alias equal
+ */
+exports.strictEqual = exports.equal
+
+/**
  * Assert object equality by content and if possible, recursively.  
  * Also handles circular and self-referential objects.
  *

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -533,6 +533,12 @@ function getValueOf(obj) {
 }
 
 /**
+ * @method deepEqual
+ * @alias eql
+ */
+exports.deepEqual = exports.eql
+
+/**
  * Assert object includes `expected`.
  *
  * For strings it checks the text, for arrays it checks elements and for

--- a/test/assertions_test.js
+++ b/test/assertions_test.js
@@ -892,6 +892,12 @@ describe("Must.prototype.equal", function() {
   })
 })
 
+describe("Must.prototype.strictEqual", function() {
+  it("must be an alias of Must.prototype.equal", function() {
+    assert.strictEqual(Must.prototype.strictEqual, Must.prototype.equal)
+  })
+})
+
 describe("Must.prototype.eql", function() {
   it("must pass given nulls", function() {
     assertPass(function() { Must(null).be.eql(null) })

--- a/test/assertions_test.js
+++ b/test/assertions_test.js
@@ -1435,6 +1435,12 @@ describe("Must.prototype.eql", function() {
   })
 })
 
+describe("Must.prototype.deepEqual", function() {
+  it("must be an alias of Must.prototype.eql", function() {
+    assert.strictEqual(Must.prototype.deepEqual, Must.prototype.eql)
+  })
+})
+
 describe("Must.prototype.empty", function() {
   describe("given Boolean", function() {
     it("must fail given a true literal", function() {


### PR DESCRIPTION
In response to issue #21 I propose adding the following two aliases:
- `Must.prototype.deepEqual` as an alias of `Must.prototype.eql`
- `Must.prototype.strictEqual` as an alias of `Must.prototype.equal`

Unit tests and docs included