### PR TITLE
Expose methods for use by plugins

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1008,6 +1008,8 @@ function insist(ok, message, expected, opts) {
   throw new AssertionError(msg, opts)
 }
 
+exports.insist = insist;
+
 function chain(fn) {
   fn.apply = fn.apply
   fn.bind = fn.bind

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1020,6 +1020,8 @@ function chain(fn) {
   return fn
 }
 
+exports.chain = chain;
+
 function enumerableKeys(obj) {
   var keys = []
   for (var key in obj) keys.push(key)

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -845,6 +845,8 @@ function isEnumerable(obj, name) {
   return false
 }
 
+exports.isEnumerable = isEnumerable;
+
 /**
  * @method nonenumerableProperty
  * @alias nonenumerable


### PR DESCRIPTION
As I mentioned in #24, exposing methods line `.insist()` and `.chain()` are good way to allow plugins to interact with`js-must`. I also found the `.isEnumerable()` method to be quite useful, so I included it in this PR as well.

Once you merge this I have some plugins ready to go. :-)