### PR TITLE
Map-based implementation of `permutationOf`

### DIFF
--- a/must.js
+++ b/must.js
@@ -611,11 +611,25 @@ function isPermutationOf(actual, expected) {
   if (!Array.isArray(actual) || !Array.isArray(expected)) return false
   if (actual.length !== expected.length) return false
 
-  actual = actual.slice().sort()
-  expected = expected.slice().sort()
-  for (var i = 0; i < actual.length; i++) {
-    if (actual[i] !== expected[i]) return false
+  var expectedElementCount = new Map()
+  for (var i = 0; i < expected.length; ++i) {
+    var element = expected[i]
+    var count = expectedElementCount.get(element) || 0
+    expectedElementCount.set(element, count + 1)
   }
+
+  for (var i = 0; i < actual.length; ++i) {
+    var element = actual[i]
+    var count = expectedElementCount.get(element)
+    if (!count) return false
+    if (count === 1) {
+      expectedElementCount.delete(element)
+    } else {
+      expectedElementCount.set(element, count - 1)
+    }
+  }
+
+  if (expectedElementCount.size) return false
 
   return true
 }


### PR DESCRIPTION
Fixes #38

This should make `permutationOf` work correctly for arrays containing values other than strings, numbers and booleans.