### PR TITLE
Map-based implementation of `permutationOf`, attempt 2

### DIFF
--- a/lib/es6.js
+++ b/lib/es6.js
@@ -15,3 +15,48 @@ exports.endsWith = String.prototype.endsWith ?
   function(haystack, needle) {
   return haystack.indexOf(needle, haystack.length - needle.length) >= 0
 }
+
+// A *very* crude Map ponyfill, supports only: size, get, set, delete
+exports.Map = typeof Map !== 'undefined' ?
+  Map :
+  (function () {
+  function Map () {
+    this._keys = []
+    this._values = []
+    this.size = 0
+  }
+
+  Map.prototype.get = function (key) {
+    var i = this._keys.indexOf(key)
+
+    if (i > -1) return this._values[i]
+  }
+
+  Map.prototype.set = function (key, value) {
+    var i = this._keys.indexOf(key)
+
+    if (i === -1) {
+      i = this._keys.length
+      this._keys[i] = key
+      ++this.size
+    }
+
+    this._values[i] = value
+    return this
+  }
+
+  Map.prototype.delete = function (key) {
+    var i = this._keys.indexOf(key)
+
+    if (i > -1) {
+      this._keys.splice(i, 1)
+      this._values.splice(i, 1)
+      --this.size
+      return true
+    }
+
+    return false
+  }
+
+  return Map
+})()

--- a/must.js
+++ b/must.js
@@ -611,11 +611,25 @@ function isPermutationOf(actual, expected) {
   if (!Array.isArray(actual) || !Array.isArray(expected)) return false
   if (actual.length !== expected.length) return false
 
-  actual = actual.slice().sort()
-  expected = expected.slice().sort()
-  for (var i = 0; i < actual.length; i++) {
-    if (actual[i] !== expected[i]) return false
+  var expectedElementCount = new Map()
+  for (var i = 0; i < expected.length; ++i) {
+    var element = expected[i]
+    var count = expectedElementCount.get(element) || 0
+    expectedElementCount.set(element, count + 1)
   }
+
+  for (var i = 0; i < actual.length; ++i) {
+    var element = actual[i]
+    var count = expectedElementCount.get(element)
+    if (!count) return false
+    if (count === 1) {
+      expectedElementCount.delete(element)
+    } else {
+      expectedElementCount.set(element, count - 1)
+    }
+  }
+
+  if (expectedElementCount.size) return false
 
   return true
 }

--- a/must.js
+++ b/must.js
@@ -11,6 +11,7 @@ var defineGetter = O.defineGetter
 var lookupGetter = O.lookupGetter
 var startsWith = require("./lib/es6").startsWith
 var endsWith = require("./lib/es6").endsWith
+var Map = require("./lib/es6").Map
 var ANY = {}
 exports = module.exports = Must
 exports.AssertionError = AssertionError

--- a/test/must/permutation_of_test.js
+++ b/test/must/permutation_of_test.js
@@ -2,24 +2,33 @@ var Must = require("../..")
 var assert = require("./assert")
 
 describe("Must.prototype.permutationOf", function() {
+  var o1 = {}
+  var o2 = {}
+  var o3 = {}
+
   it("must pass if given array has same members", function() {
     assert.pass(function() { Must([1, 2, 3]).be.a.permutationOf([3, 2, 1]) })
+    assert.pass(function() { Must([o1, o2, o3]).be.a.permutationOf([o3, o2, o1]) })
   })
 
   it("must fail if given array does not have same members", function() {
     assert.fail(function() { Must([1, 2, 3]).be.a.permutationOf([1]) })
+    assert.fail(function() { Must([o1, o2, o3]).be.a.permutationOf([o1]) })
   })
 
   it("must fail if given array is missing duplicated members", function() {
     assert.fail(function() { Must([1, 2]).be.a.permutationOf([2, 1, 1]) })
+    assert.fail(function() { Must([o1, o2]).be.a.permutationOf([o2, o1, o1]) })
   })
 
   it("must fail if given array has extra duplicated members", function() {
     assert.fail(function() { Must([1, 1, 2]).be.a.permutationOf([2, 1]) })
+    assert.fail(function() { Must([o1, o1, o2]).be.a.permutationOf([o2, o1]) })
   })
 
   it("must pass if given array has same duplicated members", function() {
     assert.pass(function() { Must([1, 1, 2]).be.a.permutationOf([2, 1, 1]) })
+    assert.pass(function() { Must([o1, o1, o2]).be.a.permutationOf([o2, o1, o1]) })
   })
 
   it("must pass if both arrays empty", function() {


### PR DESCRIPTION
Another attempt at fixing #38. Implementation of `permutationOf` is the same as in previous (failed) pull request #40. What's new here is updated tests and `Map` ponyfill for older environments like Node.js 0.10.