### PR TITLE
Added Object global augmentation typescript definition

### DIFF
--- a/must.d.ts
+++ b/must.d.ts
@@ -87,6 +87,9 @@ declare global {
     interface Number {
         must: Must;
     }
+    interface Object {
+        must: Must;
+    }
     interface Array<T> {
         must: Must;
     }


### PR DESCRIPTION
This PR patches the typescript definition file adding in the missing Object global augmentation definition, adding support for the following:

```typescript
({}).must.be.an.object();
```