### PR TITLE
Show expected and actual length for legnth error

### DIFF
--- a/must.js
+++ b/must.js
@@ -1223,6 +1223,7 @@ Must.prototype.assert = function assert(ok, message, opts) {
   var msg = stringify(this.actual) + " must " + (this.negative ? "not " : "")
   if (typeof message == "function") msg += message.call(this)
   else msg += message + ("expected" in opts ? " "+stringify(opts.expected) : "")
+  if ("have length of" == message) msg += ". +expected, -actual : +" + opts.expected + " -" + this.actual.length
   if (this.message != null) msg = this.message + ": " + msg
 
   throw new AssertionError(msg, opts)

--- a/test/must/length_test.js
+++ b/test/must/length_test.js
@@ -27,7 +27,7 @@ describe("Must.prototype.length", function() {
   }, {
     actual: "hello",
     expected: 42,
-    message: "\"hello\" must have length of 42"
+    message: "\"hello\" must have length of 42. +expected, -actual : +42 -5"
   })
 
   describe(".not", function() {


### PR DESCRIPTION
This PR adds the actual and expected size for length errors. This is useful when an assert is performed on a large array or string without knowing the length of it. Also, I would like to display the actual and expected sizes on two separate lines, but adding line break cause the tests to fail with this error : "AssertionError: must have test at top"