### PR TITLE
prevent an UnhandledPromiseRejectionWarning in the tests for reject

### DIFF
--- a/test/must/reject_test.js
+++ b/test/must/reject_test.js
@@ -6,6 +6,7 @@ describe("Must.prototype.reject", function() {
   it("must return a promise from a matcher", function() {
     var promise = Must(Promise.resolve(42)).reject.number()
     assert.strictEqual(typeof promise.then, "function")
+    return promise.then(raise, assertThrown) // prevent UnhandledPromiseRejectionWarning
   })
 
   it("must resolve given a rejected promise with expected value", function() {


### PR DESCRIPTION
Since I love must since about a week (really):

The test suite currently generates a UnhandledPromiseRejectionWarning in the tests for Must.prototype.reject on at least node  v6.11.2

This is bothering me :-P.

This PR contains 1 line of code that prevents the UnhandledPromiseRejectionWarning in the tests for Must.prototype.reject.