### PR TITLE
Fulfill or betray promises

### DIFF
--- a/must.d.ts
+++ b/must.d.ts
@@ -8,6 +8,8 @@ interface Must {
     be: CallableMust;
     before(expected): Must;
     below(expected): Must;
+    betray<TResult>(catchCondition?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+    betray(catchCondition?: (reason: any) => void): Promise<any>;
     between(begin, end): Must;
     boolean(): Must;
     contain(expected): Must;
@@ -24,6 +26,8 @@ interface Must {
     false(): Must;
     falsy(): Must;
     frozen(): Must;
+    fulfill<TResult>(fulfilledCondition?: (value?: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+    fulfill(fulfilledCondition?: (value?: any) => void): Promise<any>;
     function(): Must;
     gt(expected: number): Must;
     gte(expected: number): Must;
@@ -52,6 +56,7 @@ interface Must {
     ownProperties(properties: any): Must;
     ownProperty(property: string, value?): Must;
     permutationOf(expected: Array<any>): Must;
+    promise(): Must;
     properties(properties: any): Must;
     property(property: string, value?): Must;
     regexp(): Must;
@@ -92,5 +97,42 @@ declare global {
     }
     interface Array<T> {
         must: Must;
+    }
+
+    // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/es6-shim/index.d.ts
+    interface PromiseLike<T> {
+        /**
+         * Attaches callbacks for the resolution and/or rejection of the Promise.
+         * @param onfulfilled The callback to execute when the Promise is resolved.
+         * @param onrejected The callback to execute when the Promise is rejected.
+         * @returns A Promise for the completion of which ever callback is executed.
+         */
+        then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): PromiseLike<TResult>;
+
+        then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): PromiseLike<TResult>;
+    }
+
+    /**
+     * Represents the completion of an asynchronous operation
+     */
+    interface Promise<T> {
+        /**
+         * Attaches callbacks for the resolution and/or rejection of the Promise.
+         * @param onfulfilled The callback to execute when the Promise is resolved.
+         * @param onrejected The callback to execute when the Promise is rejected.
+         * @returns A Promise for the completion of which ever callback is executed.
+         */
+        then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+
+        then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
+
+        /**
+         * Attaches a callback for only the rejection of the Promise.
+         * @param onrejected The callback to execute when the Promise is rejected.
+         * @returns A Promise for the completion of the callback.
+         */
+        catch(onrejected?: (reason: any) => T | PromiseLike<T>): Promise<T>;
+
+        catch(onrejected?: (reason: any) => void): Promise<T>;
     }
 }

--- a/must.js
+++ b/must.js
@@ -1268,6 +1268,43 @@ Must.prototype.fulfill = function(fulfilledCondition) {
              .then(fulfilledCondition || nop)
 }
 
+/**
+ * Assert that an object is a promise (see `promise`), that eventually rejects ("betrays" the promise).
+ * The assertion returns a promise that settles to the outcome (resolve result or
+ * reject error) of `catchCondition`. `catchCondition` is called with the
+ * error (reject result) of the original promise when it rejects.
+ * If the original promise is fulfilled (resolved), this assertion fails, and `catchCondition`
+ * is not called. `catchCondition` is optional.
+ *
+ * This approach makes it possible to immediate express assertions about the original
+ * promise's reject error.
+ *
+ * @example
+ * Promise.reject(new Error()).must.betray()
+ * Promise.reject(42).must.betray(function(err) {
+ *   err.must.be.a.number()
+ *   err.must.be.truthy()
+ *   return result // the resulting promise will be fulfilled
+ * })
+ * Promise.reject(42).must.betray(function(err) {
+ *   err.must.be.a.number()
+ *   err.must.be.truthy()
+ *   throw result // the resulting promise will be rejected
+ * })
+ * Promise.reject(42).must.betray(function(err) {
+ *   err.must.not.be.a.number() // fails
+ *   err.must.be.truthy()
+ *   return result
+ * })
+ * Promise.resolve(42).must.betray(function(err) { // betray fails, callback is not executed
+ *   err.must.not.be.a.number()
+ *   err.must.be.truthy()
+ *   return result
+ * })
+ *
+ * @method betray
+ * @param catchCondition
+ */
 defineGetter(Must.prototype, "betray", function(catchCondition) {
   var must = this
   must.promise()

--- a/must.js
+++ b/must.js
@@ -1184,7 +1184,7 @@ defineGetter(Must.prototype, "reject", function() {
 })
 
 /**
- * Assert that an object is a promise.
+ * Assert that an object is a promise, and returns it.
  *
  * The determination uses duck typing, i.e., it checks whether the object has
  * a `then` and a `catch` method.
@@ -1213,6 +1213,7 @@ defineGetter(Must.prototype, "reject", function() {
  */
 Must.prototype.promise = function() {
   this.assert(isPromise(this.actual), isPromiseMsg, { actual: this.actual })
+  return this.actual
 }
 
 /**

--- a/must.js
+++ b/must.js
@@ -1183,6 +1183,34 @@ defineGetter(Must.prototype, "reject", function() {
   return Rejectable(this)
 })
 
+/**
+ * Assert that an object is a promise.
+ *
+ * The determination uses duck typing, i.e., it checks whether the object has
+ * a `then` and a `catch` method.
+ *
+ * There are several implementations of promises in the wild, and a promise you
+ * receive from a library might not be an `instanceof` _your_ `Promise` type,
+ * although they can work together.
+ *
+ * ```javascript
+ * promise.must.be.a(Promise)
+ * ```
+ *
+ * might fail, while
+ *
+ * ```javascript
+ * promise.must.be.a.promise
+ * ```
+ *
+ * might be upheld.
+ *
+ * @example
+ * Promise.resolve(42).must.be.a.promise()
+ * Promise.reject(42).must.be.a.promise()
+ *
+ * @method promise
+ */
 defineGetter(Must.prototype, "promise", function() {
   this.assert(
     typeof this.actual.then === "function" && typeof this.actual.catch === "function",

--- a/must.js
+++ b/must.js
@@ -1268,6 +1268,17 @@ Must.prototype.fulfill = function(fulfilledCondition) {
              .then(fulfilledCondition || nop)
 }
 
+defineGetter(Must.prototype, "betray", function(catchCondition) {
+  var must = this
+  must.promise()
+  return must.actual.then(
+    function(result) {
+      must.assert(false, "reject, but got fulfilled with \'" + stringify(result) + "\'")
+    },
+    catchCondition || nop
+  )
+})
+
 /**
  * Assert a string starts with the given string.
  *

--- a/must.js
+++ b/must.js
@@ -1226,6 +1226,9 @@ Must.prototype.promise = function() {
  * This approach makes it possible to immediate express assertions about the original
  * promise's resolve result.
  *
+ * You should not use `not` to negate `fulfill`. Things will get weird. Use `betray`
+ * to express that the promise should be rejected instead.
+ *
  * @example
  * Promise.resolve(42).must.fulfill()
  * Promise.resolve(42).must.fulfill(function(result) {
@@ -1275,6 +1278,9 @@ Must.prototype.fulfill = function(fulfilledCondition) {
  *
  * This approach makes it possible to immediate express assertions about the original
  * promise's reject error.
+ *
+ * You should not use `not` to negate `betray`. Things will get weird. Use `fulfill`
+ * to express that the promise should be resolved instead.
  *
  * @example
  * Promise.reject(new Error()).must.betray()

--- a/must.js
+++ b/must.js
@@ -1258,7 +1258,7 @@ function nop() {}
  * @method fulfill
  * @param fulfilledCondition
  */
-defineGetter(Must.prototype, "fulfill", function(fulfilledCondition) {
+Must.prototype.fulfill = function(fulfilledCondition) {
   var must = this
   must.promise()
   return must.actual
@@ -1266,7 +1266,7 @@ defineGetter(Must.prototype, "fulfill", function(fulfilledCondition) {
                 must.assert(false, "resolve, but got rejected with \'" + err.message + "\'")
               })
              .then(fulfilledCondition || nop)
-})
+}
 
 /**
  * Assert a string starts with the given string.

--- a/must.js
+++ b/must.js
@@ -1305,7 +1305,7 @@ Must.prototype.fulfill = function(fulfilledCondition) {
  * @method betray
  * @param catchCondition
  */
-defineGetter(Must.prototype, "betray", function(catchCondition) {
+Must.prototype.betray = function(catchCondition) {
   var must = this
   must.promise()
   return must.actual.then(
@@ -1314,7 +1314,7 @@ defineGetter(Must.prototype, "betray", function(catchCondition) {
     },
     catchCondition || nop
   )
-})
+}
 
 /**
  * Assert a string starts with the given string.

--- a/must.js
+++ b/must.js
@@ -1213,8 +1213,9 @@ defineGetter(Must.prototype, "reject", function() {
  */
 defineGetter(Must.prototype, "promise", function() {
   this.assert(
-    typeof this.actual.then === "function" && typeof this.actual.catch === "function",
-    "be a promise (i.e., have a \'then\' and a \'catch\' function)"
+    this.actual && typeof this.actual.then === "function" && typeof this.actual.catch === "function",
+    "be a promise (i.e., have a \'then\' and a \'catch\' function)",
+    { actual: this.actual }
   )
 })
 

--- a/must.js
+++ b/must.js
@@ -1183,6 +1183,13 @@ defineGetter(Must.prototype, "reject", function() {
   return Rejectable(this)
 })
 
+defineGetter(Must.prototype, "promise", function() {
+  this.assert(
+    typeof this.actual.then === "function" && typeof this.actual.catch === "function",
+    "be a promise (i.e., have a \'then\' and a \'catch\' function)"
+  )
+})
+
 /**
  * Assert a string starts with the given string.
  *

--- a/must.js
+++ b/must.js
@@ -1311,10 +1311,18 @@ Must.prototype.fulfill = function(fulfilledCondition) {
 Must.prototype.betray = function(catchCondition) {
   var must = this
   must.assert(isPromise(this.actual), isPromiseMsg, {actual: this.actual})
-  var resolved = must.actual.then(function(result) {
-    must.assert(false, "reject, but got fulfilled with \'" + stringify(result) + "\'")
-  })
-  return catchCondition ? resolved.catch(catchCondition) : resolved
+  return must.actual.then(
+    function(result) {
+      must.assert(
+        false,
+        "reject, but got fulfilled with \'" + stringify(result) + "\'",
+        {actual: must.actual}
+      )
+    },
+    catchCondition
+      ? catchCondition
+      : function(err) { throw err }
+  )
 }
 
 /**

--- a/must.js
+++ b/must.js
@@ -1211,13 +1211,13 @@ defineGetter(Must.prototype, "reject", function() {
  *
  * @method promise
  */
-defineGetter(Must.prototype, "promise", function() {
+Must.prototype.promise = function() {
   this.assert(
     this.actual && typeof this.actual.then === "function" && typeof this.actual.catch === "function",
     "be a promise (i.e., have a \'then\' and a \'catch\' function)",
     { actual: this.actual }
   )
-})
+}
 
 /**
  * Assert a string starts with the given string.

--- a/must.js
+++ b/must.js
@@ -1221,6 +1221,16 @@ Must.prototype.promise = function() {
 
 function nop() {}
 
+defineGetter(Must.prototype, "fulfill", function(fulfilledCondition) {
+  var must = this
+  must.promise()
+  return must.actual
+             .catch(function(err) {
+                must.assert(false, "resolve, but got rejected with \'" + err.message + "\'")
+              })
+             .then(fulfilledCondition || nop)
+})
+
 /**
  * Assert a string starts with the given string.
  *

--- a/must.js
+++ b/must.js
@@ -1221,6 +1221,43 @@ Must.prototype.promise = function() {
 
 function nop() {}
 
+/**
+ * Assert that an object is a promise (see `promise`), that eventually resolves.
+ * The assertion returns a promise that settles to the outcome (resolve result or
+ * reject error) of `fulfilledCondition`. `fulfilledCondition` is called with the
+ * resolution (resolve result) of the original promise when it resolves.
+ * If the original promise is rejected, this assertion fails, and `fulfilledCondition`
+ * is not called. `fulfilledCondition` is optional.
+ *
+ * This approach makes it possible to immediate express assertions about the original
+ * promise's resolve result.
+ *
+ * @example
+ * Promise.resolve(42).must.fulfill()
+ * Promise.resolve(42).must.fulfill(function(result) {
+ *   result.must.be.a.number()
+ *   result.must.be.truthy()
+ *   return result // the resulting promise will be fulfilled
+ * })
+ * Promise.resolve(42).must.fulfill(function(result) {
+ *   result.must.be.a.number()
+ *   result.must.be.truthy()
+ *   throw result // the resulting promise will be rejected
+ * })
+ * Promise.resolve(42).must.fulfill(function(result) {
+ *   result.must.not.be.a.number() // fails
+ *   result.must.be.truthy()
+ *   return result
+ * })
+ * Promise.reject(new Error()).must.fulfill(function(result) { // fulfill fails, callback is not executed
+ *   result.must.not.be.a.number()
+ *   result.must.be.truthy()
+ *   return result
+ * })
+ *
+ * @method fulfill
+ * @param fulfilledCondition
+ */
 defineGetter(Must.prototype, "fulfill", function(fulfilledCondition) {
   var must = this
   must.promise()

--- a/must.js
+++ b/must.js
@@ -1212,11 +1212,7 @@ defineGetter(Must.prototype, "reject", function() {
  * @method promise
  */
 Must.prototype.promise = function() {
-  this.assert(
-    this.actual && typeof this.actual.then === "function" && typeof this.actual.catch === "function",
-    "be a promise (i.e., have a \'then\' and a \'catch\' function)",
-    { actual: this.actual }
-  )
+  this.assert(isPromise(this.actual), isPromiseMsg, { actual: this.actual })
 }
 
 function nop() {}
@@ -1260,12 +1256,12 @@ function nop() {}
  */
 Must.prototype.fulfill = function(fulfilledCondition) {
   var must = this
-  must.promise()
   return must.actual
              .catch(function(err) {
                 must.assert(false, "resolve, but got rejected with \'" + err.message + "\'")
               })
              .then(fulfilledCondition || nop)
+  must.assert(isPromise(this.actual), isPromiseMsg, {actual: this.actual})
 }
 
 /**
@@ -1307,13 +1303,13 @@ Must.prototype.fulfill = function(fulfilledCondition) {
  */
 Must.prototype.betray = function(catchCondition) {
   var must = this
-  must.promise()
   return must.actual.then(
     function(result) {
       must.assert(false, "reject, but got fulfilled with \'" + stringify(result) + "\'")
     },
     catchCondition || nop
   )
+  must.assert(isPromise(this.actual), isPromiseMsg, {actual: this.actual})
 }
 
 /**
@@ -1418,4 +1414,10 @@ function messageFromError(err) {
 
 function isFn(fn) { return typeof fn === "function" }
 function isNumber(n) { return typeof n === "number" || n instanceof Number }
+
+var isPromiseMsg = "be a promise (i.e., have a \'then\' and a \'catch\' function)"
+function isPromise(p) {
+  return p && typeof p.then === "function" && typeof p.catch === "function"
+}
+
 function passthrough() { return this }

--- a/must.js
+++ b/must.js
@@ -1219,6 +1219,8 @@ Must.prototype.promise = function() {
   )
 }
 
+function nop() {}
+
 /**
  * Assert a string starts with the given string.
  *

--- a/test/must/_failing_promise_tests.js
+++ b/test/must/_failing_promise_tests.js
@@ -1,0 +1,66 @@
+var Must = require("../..")
+var assert = require("./assert")
+var assertionErrorTest = require("./_assertion_error_test")
+
+function dummy () {}
+
+var thenNoCatch = {then: dummy}
+var catchNoThen = {catch: dummy}
+var catchAndThen = {then: dummy, catch: dummy}
+
+module.exports = function(callToTest) {
+  it("must fail given null", function () {
+    assert.fail(function () { callToTest(Must(null)) })
+  })
+
+  it("must fail given undefined", function () {
+    assert.fail(function () { callToTest(Must(undefined)) })
+  })
+
+  it("must fail given boolean primitive", function () {
+    assert.fail(function () { callToTest(Must(true)) })
+    assert.fail(function () { callToTest(Must(false)) })
+  })
+
+  it("must fail given number primitive", function () {
+    assert.fail(function () { callToTest(Must(42)) })
+  })
+
+  it("must fail given string primitive", function () {
+    assert.fail(function () { callToTest(Must("")) })
+  })
+
+  it("must fail given array", function () {
+    assert.fail(function () { callToTest(Must([])) })
+  })
+
+  it("must fail given object", function () {
+    assert.fail(function () { callToTest(Must({})) })
+  })
+
+  it("must fail given an object with a then function, but not a catch function", function () {
+    assert.fail(function () { callToTest(Must(thenNoCatch)) })
+  })
+
+  it("must fail given an object with a catch function, but not a then function", function () {
+    assert.fail(function () { callToTest(Must(catchNoThen)) })
+  })
+
+  assertionErrorTest(
+    function() { callToTest(Must(catchNoThen)) },
+    {
+      actual: catchNoThen,
+      message: "{} must be a promise (i.e., have a \'then\' and a \'catch\' function)"
+    }
+  )
+
+  describe(".not", function() {
+    it("must invert the assertion", function() {
+      assert.fail(function() { callToTest(Must(catchAndThen).not) })
+    })
+  })
+}
+
+module.exports.thenNoCatch = thenNoCatch
+module.exports.catchNoThen = catchNoThen
+module.exports.catchAndThen = catchAndThen

--- a/test/must/betray_test.js
+++ b/test/must/betray_test.js
@@ -1,0 +1,131 @@
+var Promise = global.Promise || require("promise")
+var Must = require("../..")
+var failingPromiseTests = require("./_failing_promise_tests")
+var assert = require("./assert")
+var stringify = require("../../lib").stringify
+
+describe("Must.prototype.betray", function() {
+  failingPromiseTests(function(must) { must.betray() })
+
+  it(
+    "must pass given a Promise that rejects, and eventually pass, and reject itself",
+    function(done) {
+      var rejection = new Error()
+      assert.pass(
+        function() { Must(Promise.reject(rejection)).betray().then(raise(done), assertStrictEqual(done, rejection)) }
+      )
+    }
+  )
+
+  it("must pass given a Promise that resolves, and eventually fail", function(done) {
+    assert.pass(function() { Must(Promise.resolve(42)).betray().then(raise(done), assertThrown(done)) })
+  })
+
+  it(
+    "must pass given a Promise that rejects and a catchCondition that returns, " +
+    "and eventually pass, and resolve to the result of the catchCondition",
+    function(done) {
+      var called = false
+      assert.pass(function() {
+        Must(Promise.reject(42)).betray(function(result) {
+          called = true
+          result.must.be.a.number()
+          result.must.be.truthy()
+          return result // the resulting promise will be fulfilled
+        }).then(assertStrictEqual(done, 42, function() { return called }), raise(done))
+      })
+    }
+  )
+
+  it(
+    "must pass given a Promise that rejects and a catchCondition that throws, " +
+    "and eventually pass, and reject to the rejection of the catchCondition",
+    function(done) {
+      var called = false
+      assert.pass(function() {
+        Must(Promise.reject(43).betray(function(err) {
+          called = true
+          err.must.be.a.number()
+          err.must.be.truthy()
+          throw err // the resulting promise will be rejected
+        })
+        .then(raise(done), assertStrictEqual(done, 42, function() { return called })))
+      })
+    }
+  )
+
+  it(
+    "must pass given a Promise that rejects and a catchCondition that fails, and eventually fail",
+    function(done) {
+      var called = false
+      assert.pass(function() {
+        Must(Promise.reject(42)).betray(function(result) {
+          called = true
+          result.must.not.be.a.number() // fails
+          result.must.be.truthy()
+          return result
+        })
+        .then(raise(done), assertThrown(done, function() { return called }))
+      })
+    }
+  )
+
+  it(
+    "must pass given a Promise that resolves, and eventually fail, without calling the catchCondition",
+    function(done) {
+      var called = false
+      assert.pass(function() {
+        Must(Promise.resolve(42)).betray(function() { // betray fails, callback is not executed
+          called = true
+        })
+        .then(raise(done), assertThrown(done, function() { return !called }))
+      })
+    }
+  )
+
+  it("AssertionError must have all properties when it fails because of a resolution", function(done) {
+    var resolution = 42
+    var subject = Promise.resolve(resolution)
+    Must(subject).betray().then(
+      raise(done),
+      function(err) {
+        assert(err instanceof Must.AssertionError)
+        assert.deepEqual(
+          err,
+          {
+            actual: subject,
+            message: "{} must reject, but got fulfilled with \'" + stringify(resolution) + "\'"
+          }
+        )
+        done()
+      }
+    )
+  })
+
+})
+
+function assertStrictEqual(done, expected, called) {
+  return function(value) {
+    if (called) {
+      assert(called())
+    }
+    assert.strictEqual(value, expected)
+    done()
+  }
+}
+function assertThrown(done, called) {
+  return function(err) {
+    if (called) {
+      assert(called())
+    }
+    if (err instanceof Must.AssertionError) {
+      done()
+    }
+    else {
+      done(new Error("not a Must.AssertionError: " + err.message))
+    }
+  }
+}
+function raise(done) {
+  return function() { done(new Error("Must fail")) }
+}

--- a/test/must/betray_test.js
+++ b/test/must/betray_test.js
@@ -37,19 +37,19 @@ describe("Must.prototype.betray", function() {
     }
   )
 
-  it( // MUDO this test has issues
+  it(
     "must pass given a Promise that rejects and a catchCondition that throws, " +
     "and eventually pass, and reject to the rejection of the catchCondition",
     function(done) {
       var called = false
       assert.pass(function() {
-        Must(Promise.reject(43).betray(function(err) {
+        Must(Promise.reject(42)).betray(function(err) {
           called = true
           err.must.be.a.number()
           err.must.be.truthy()
           throw err // the resulting promise will be rejected
         })
-        .then(raise(done), assertStrictEqual(done, 42, function() { return called })))
+        .then(raise(done), assertStrictEqual(done, 42, function() { return called }))
       })
     }
   )

--- a/test/must/betray_test.js
+++ b/test/must/betray_test.js
@@ -37,7 +37,7 @@ describe("Must.prototype.betray", function() {
     }
   )
 
-  it(
+  it( // MUDO this test has issues
     "must pass given a Promise that rejects and a catchCondition that throws, " +
     "and eventually pass, and reject to the rejection of the catchCondition",
     function(done) {

--- a/test/must/fulfill_test.js
+++ b/test/must/fulfill_test.js
@@ -72,11 +72,8 @@ describe("Must.prototype.fulfill", function() {
     function(done) {
       var called = false
       assert.pass(function() {
-        Must(Promise.reject(new Error('rejection'))).fulfill(function(result) { // fulfill fails, callback is not executed
+        Must(Promise.reject(new Error('rejection'))).fulfill(function() { // fulfill fails, callback is not executed
           called = true
-          result.must.not.be.a.number() // fails
-          result.must.be.truthy()
-          return result
         })
         .then(raise(done), assertThrown(done, function() { return !called }))
       })

--- a/test/must/fulfill_test.js
+++ b/test/must/fulfill_test.js
@@ -1,0 +1,131 @@
+var Promise = global.Promise || require("promise")
+var Must = require("../..")
+var failingPromiseTests = require("./_failing_promise_tests")
+var assert = require("./assert")
+
+describe("Must.prototype.fulfill", function() {
+  failingPromiseTests(function(must) { must.fulfill() })
+
+  it("must pass given a Promise that rejects, and eventually fail", function(done) {
+    assert.pass(function() { Must(Promise.reject(new Error())).fulfill().then(raise(done),assertThrown(done)) })
+  })
+
+  it(
+    "must pass given a Promise that resolves, and eventually pass, and resolve itself",
+    function(done) {
+      assert.pass(function() { Must(Promise.resolve(42)).fulfill().then(assertStrictEqual(done, 42), raise(done)) })
+    }
+  )
+
+  it(
+    "must pass given a Promise that resolves and a fulfilledCondition that returns, " +
+    "and eventually pass, and resolve to the result of the fulfilledCondition",
+    function(done) {
+      var called = false
+      assert.pass(function() {
+        Must(Promise.resolve(42)).fulfill(function(result) {
+          called = true
+          result.must.be.a.number()
+          result.must.be.truthy()
+          return result // the resulting promise will be fulfilled
+        })
+        .then(assertStrictEqual(done, 42, function() { return called }), raise(done))
+      })
+    }
+  )
+
+  it(
+    "must pass given a Promise that resolves and a fulfilledCondition that throws, " +
+    "and eventually pass, and reject to the rejection of the fulfilledCondition",
+    function(done) {
+      var called = false
+      assert.pass(function() {
+        Must(Promise.resolve(42)).fulfill(function(result) {
+          called = true
+          result.must.be.a.number()
+          result.must.be.truthy()
+          throw result // the resulting promise will be rejected
+        })
+        .then(raise(done), assertStrictEqual(done, 42, function() { return called }))
+      })
+    }
+  )
+
+  it(
+    "must pass given a Promise that resolves and a fulfilledCondition that fails, and eventually fail",
+    function(done) {
+      var called = false
+      assert.pass(function() {
+        Must(Promise.resolve(42)).fulfill(function(result) {
+          called = true
+          result.must.not.be.a.number() // fails
+          result.must.be.truthy()
+          return result
+        })
+        .then(raise(done), assertThrown(done, function() { return called }))
+      })
+    }
+  )
+
+  it(
+    "must pass given a Promise that rejects, and eventually fail, without calling the fulfilledCondition",
+    function(done) {
+      var called = false
+      assert.pass(function() {
+        Must(Promise.reject(new Error('rejection'))).fulfill(function(result) { // fulfill fails, callback is not executed
+          called = true
+          result.must.not.be.a.number() // fails
+          result.must.be.truthy()
+          return result
+        })
+        .then(raise(done), assertThrown(done, function() { return !called }))
+      })
+    }
+  )
+
+  it("AssertionError must have all properties when it fails because of a rejection", function(done) {
+    var message = "rejection message"
+    var subject = Promise.reject(new Error(message))
+    Must(subject).fulfill().then(
+      raise(done),
+      function(err) {
+        assert(err instanceof Must.AssertionError)
+        assert.deepEqual(
+          err,
+          {
+            actual: subject,
+            message: "{} must resolve, but got rejected with \'" + message + "\'"
+          }
+        )
+        done()
+      }
+    )
+  })
+
+})
+
+function assertStrictEqual(done, expected, called) {
+  return function(value) {
+    if (called) {
+      assert(called())
+    }
+    assert.strictEqual(value, expected)
+    done()
+  }
+}
+function assertThrown(done, called) {
+  return function(err) {
+    if (called) {
+      assert(called())
+    }
+    if (err instanceof Must.AssertionError) {
+      done()
+    }
+    else {
+      done(new Error("not a Must.AssertionError: " + err.message))
+    }
+  }
+}
+function raise(done) {
+  return function() { done(new Error("Must fail")) }
+}

--- a/test/must/promise_test.js
+++ b/test/must/promise_test.js
@@ -45,16 +45,16 @@ describe("Must.prototype.promise", function() {
     assert.fail(function () { Must(catchNoThen).be.promise() })
   })
 
-  it("must pass given an object with a catch and a then function", function () { // NOK
+  it("must pass given an object with a catch and a then function", function () {
     assert.pass(function () { Must(catchAndThen).be.promise() })
   })
 
   if (Promise) {
-    it("must pass given a Promise implementation, with a resolved promise", function () { // NOK
+    it("must pass given a Promise implementation, with a resolved promise", function () {
       assert.pass(function () { Must(Promise.resolve(42)).be.promise() })
     })
 
-    it("must pass given a Promise implementation, with a rejected promise", function () { // NOK
+    it("must pass given a Promise implementation, with a rejected promise", function () {
       assert.pass(function () { Must(Promise.resolve(new Error())).be.promise() })
     })
   }

--- a/test/must/promise_test.js
+++ b/test/must/promise_test.js
@@ -1,0 +1,72 @@
+var Must = require("../..")
+var assert = require("./assert")
+
+describe("Must.prototype.promise", function() {
+  it("must fail given null", function () {
+    assert.fail(function () { Must(null).be.promise() })
+  })
+
+  it("must fail given undefined", function () {
+    assert.fail(function () { Must(undefined).be.promise() })
+  })
+
+  it("must fail given boolean primitive", function () {
+    assert.fail(function () { Must(true).be.promise() })
+    assert.fail(function () { Must(false).be.promise() })
+  })
+
+  it("must fail given number primitive", function () {
+    assert.fail(function () { Must(42).be.promise() })
+  })
+
+  it("must fail given string primitive", function () {
+    assert.fail(function () { Must("").be.promise() })
+  })
+
+  it("must fail given array", function () {
+    assert.fail(function () { Must([]).be.promise() })
+  })
+
+  it("must fail given object", function () {
+    assert.fail(function () { Must({}).be.promise() })
+  })
+
+  function dummy () {}
+
+  var thenNoCatch = {then: dummy}
+  var catchNoThen = {catch: dummy}
+  var catchAndThen = {then: dummy, catch: dummy}
+
+  it("must fail given an object with a then function, but not a catch function", function () {
+    assert.fail(function () { Must(thenNoCatch).be.promise() })
+  })
+
+  it("must fail given an object with a catch function, but not a then function", function () {
+    assert.fail(function () { Must(catchNoThen).be.promise() })
+  })
+
+  it("must pass given an object with a catch and a then function", function () { // NOK
+    assert.pass(function () { Must(catchAndThen).be.promise() })
+  })
+
+  if (Promise) {
+    it("must pass given a Promise implementation, with a resolved promise", function () { // NOK
+      assert.pass(function () { Must(Promise.resolve(42)).be.promise() })
+    })
+
+    it("must pass given a Promise implementation, with a rejected promise", function () { // NOK
+      assert.pass(function () { Must(Promise.resolve(new Error())).be.promise() })
+    })
+  }
+
+  require("./_assertion_error_test")(function() { Must(catchNoThen).be.promise() }, {
+    actual: catchNoThen,
+    message: "{} must be a promise (i.e., have a \'then\' and a \'catch\' function)"
+  })
+
+  describe(".not", function() {
+    it("must invert the assertion", function() {
+      assert.fail(function() { Must(catchAndThen).not.be.promise() })
+    })
+  })
+})

--- a/test/must/promise_test.js
+++ b/test/must/promise_test.js
@@ -15,7 +15,7 @@ describe("Must.prototype.promise", function() {
     })
 
     it("must pass given a Promise implementation, with a rejected promise", function () {
-      assert.pass(function () { Must(Promise.resolve(new Error())).be.promise() })
+      assert.pass(function () { Must(Promise.reject(new Error())).be.promise() })
     })
   }
 })

--- a/test/must/promise_test.js
+++ b/test/must/promise_test.js
@@ -1,52 +1,12 @@
 var Must = require("../..")
+var failingPromiseTests = require("./_failing_promise_tests")
 var assert = require("./assert")
 
 describe("Must.prototype.promise", function() {
-  it("must fail given null", function () {
-    assert.fail(function () { Must(null).be.promise() })
-  })
-
-  it("must fail given undefined", function () {
-    assert.fail(function () { Must(undefined).be.promise() })
-  })
-
-  it("must fail given boolean primitive", function () {
-    assert.fail(function () { Must(true).be.promise() })
-    assert.fail(function () { Must(false).be.promise() })
-  })
-
-  it("must fail given number primitive", function () {
-    assert.fail(function () { Must(42).be.promise() })
-  })
-
-  it("must fail given string primitive", function () {
-    assert.fail(function () { Must("").be.promise() })
-  })
-
-  it("must fail given array", function () {
-    assert.fail(function () { Must([]).be.promise() })
-  })
-
-  it("must fail given object", function () {
-    assert.fail(function () { Must({}).be.promise() })
-  })
-
-  function dummy () {}
-
-  var thenNoCatch = {then: dummy}
-  var catchNoThen = {catch: dummy}
-  var catchAndThen = {then: dummy, catch: dummy}
-
-  it("must fail given an object with a then function, but not a catch function", function () {
-    assert.fail(function () { Must(thenNoCatch).be.promise() })
-  })
-
-  it("must fail given an object with a catch function, but not a then function", function () {
-    assert.fail(function () { Must(catchNoThen).be.promise() })
-  })
+  failingPromiseTests(function(must) { must.promise() })
 
   it("must pass given an object with a catch and a then function", function () {
-    assert.pass(function () { Must(catchAndThen).be.promise() })
+    assert.pass(function () { Must(failingPromiseTests.catchAndThen).be.promise() })
   })
 
   if (Promise) {
@@ -58,15 +18,4 @@ describe("Must.prototype.promise", function() {
       assert.pass(function () { Must(Promise.resolve(new Error())).be.promise() })
     })
   }
-
-  require("./_assertion_error_test")(function() { Must(catchNoThen).be.promise() }, {
-    actual: catchNoThen,
-    message: "{} must be a promise (i.e., have a \'then\' and a \'catch\' function)"
-  })
-
-  describe(".not", function() {
-    it("must invert the assertion", function() {
-      assert.fail(function() { Must(catchAndThen).not.be.promise() })
-    })
-  })
 })

--- a/test/must/promise_test.js
+++ b/test/must/promise_test.js
@@ -1,3 +1,4 @@
+var Promise = global.Promise || require("promise")
 var Must = require("../..")
 var failingPromiseTests = require("./_failing_promise_tests")
 var assert = require("./assert")
@@ -9,13 +10,11 @@ describe("Must.prototype.promise", function() {
     assert.pass(function () { Must(failingPromiseTests.catchAndThen).be.promise() })
   })
 
-  if (Promise) {
-    it("must pass given a Promise implementation, with a resolved promise", function () {
-      assert.pass(function () { Must(Promise.resolve(42)).be.promise() })
-    })
+  it("must pass given a Promise implementation, with a resolved promise", function () {
+    assert.pass(function () { Must(Promise.resolve(42)).be.promise() })
+  })
 
-    it("must pass given a Promise implementation, with a rejected promise", function () {
-      assert.pass(function () { Must(Promise.reject(new Error())).be.promise() })
-    })
-  }
+  it("must pass given a Promise implementation, with a rejected promise", function () {
+    assert.pass(function () { Must(Promise.reject(new Error())).be.promise() })
+  })
 })

--- a/test/must/promise_test.js
+++ b/test/must/promise_test.js
@@ -14,7 +14,25 @@ describe("Must.prototype.promise", function() {
     assert.pass(function () { Must(Promise.resolve(42)).be.promise() })
   })
 
-  it("must pass given a Promise implementation, with a rejected promise", function () {
-    assert.pass(function () { Must(Promise.reject(new Error())).be.promise() })
+  it("must pass given a Promise implementation, with a rejected promise (and passes it through)", function(done) {
+    var p = Promise.reject(new Error())
+    assert.pass(function() { Must(p).be.promise() })
+    p.catch(function() { done() }) // deal with UnhandledPromiseRejectionWarning
+  })
+
+  it("passes through a resolved promise", function() {
+    var p = Promise.resolve(42)
+    assert(Must(p).be.promise() === p)
+  })
+
+  it("passes through a rejected promise", function(done) {
+    var rejection = new Error()
+    var p = Promise.reject(rejection)
+    var outcome = Must(p).be.promise()
+    assert(outcome === p)
+    p.catch(function(err) { // deal with UnhandledPromiseRejectionWarning
+      assert(err === rejection)
+      done()
+    })
   })
 })


### PR DESCRIPTION
I recently switched to must from chai, because I started to used Standardjs.
I do find the reasons why you created must meaningful ("Beware of libraries that assert 
on property access", "RFC 2119", …), and find myself happier with must than chai.

In both cases, I am frustrated with testing Promises.

The current `must.resolve` and `must.reject` primitives lead me to complex coding
structures, embedded in Promise.all([]) constructs far to often (the same applies to chai
and its extensions).

This is an example of a Mocha test:

	const Gatherer = …
	const domain = …
	const getDataFailure = function(…) { … }

    it('fails as described with a getData that fails', function () {
      const subject = new Gatherer({domain: domain, getData: getDataFailure})
      subject.domain.must.equal(domain)
      subject.getData.must.equal(getDataFailure)
      const initialised = subject.initialise(at)
      return Promise.all([
        initialised.must.reject,
        initialised.catch(err => {
          err.must.be.an.error(Error, /getting data/)
          subject.domain.must.equal(domain) // did not change
          subject.getData.must.equal(getDataFailure) // did not change
        })
      ])
    })

Note that the `initialised.must.reject` phrase doesn't work. There is no simple way to
express that an AssertionError should be thrown when the promise resolves, without
doing something with this (`initialised.must.reject.to…`). To work, we would need 
something of the form `initialised.must.reject()`, i.e., a method call.

If I want to say more about the returned value or error, _and_ about the state of other
things after the promise settles, I seem to be forced to use complex Promise.all([])
constructs, and variables to store intermediate results.

In this PR, I offer an alternative that seems to work in my tests. We express that
a Promise must 'fulfill' or 'betrays' its intentions. The check fails if the Promise
does not settle in the way it must. If it does, the conditions that we express in
the 'fullfil' or 'betray' argument are tested.

The whole can be returned in a test, which is the most pleasing way most test frameworks
support asynchronous tests.

With these new methods, the above test now becomes:

    it('fails as described with a getData that fails', function () {
      const subject = new Gatherer({domain: domain, getData: getDataFailure})
      subject.domain.must.equal(domain)
      subject.getData.must.equal(getDataFailure)
      return subject.initialise(at).must.betray(err => {
        err.must.be.an.error(Error, /getting data/)
        subject.domain.must.equal(domain) // did not change
        subject.getData.must.equal(getDataFailure) // did not change
      })
    })

There is much less accidental complexity in this form.

More examples are in the JS Doc.

I you find to time, it would be nice if you could review this solution, and give me
any feedback that you deem relevant.
