### PR TITLE
Improve error message for length assertion

### DIFF
--- a/must.js
+++ b/must.js
@@ -721,8 +721,9 @@ Must.prototype.throw = function(type, expected) {
  * @param expected
  */
 Must.prototype.length = function(expected) {
-  var ok = this.actual.length == expected
-  this.assert(ok, "have length of", {expected: expected})
+  var actualLength = this.actual.length
+  var ok = actualLength == expected
+  this.assert(ok, "have length of", {actual: actualLength, expected: expected})
 }
 
 /**

--- a/test/must/length_test.js
+++ b/test/must/length_test.js
@@ -25,7 +25,7 @@ describe("Must.prototype.length", function() {
   require("./_assertion_error_test")(function() {
     Must("hello").have.length(42)
   }, {
-    actual: "hello",
+    actual: "hello".length,
     expected: 42,
     message: "\"hello\" must have length of 42"
   })


### PR DESCRIPTION
Hello guys,

I like very much the js-must project as a test tool in my own project. When searching in the source code, I was interested to make the length assert error message more expressive. I modified the Must.prototype.length implementation to improve the ouput of the error message assertion. In fact, it will be more interesting to show the difference between the expected and the actual length when the assertion fails.

For example, `[2,'a'].must.have.length(3)` should return this output 
```
AssertionError: [2,"a"] must have length of 3
+ expected - actual
-2
+3
```
Or` "hello".must.have.length(3)` with the output
```
AssertionError: "hello" must have length of 3
+ expected - actual
-5
+3
```