### PR TITLE
added one more definition for use with typescript, when aliasing must as demand

### DIFF
--- a/must.d.ts
+++ b/must.d.ts
@@ -73,6 +73,7 @@ interface CallableMust extends Must {
     (): Must;
 }
 declare function must(expected: any): Must;
+declare function must(expected: any, msg?: string): Must;
 declare namespace must {}
 
 export = must;


### PR DESCRIPTION
When using typescript compiler, if we want to alias must as demand, following the example here:

https://github.com/moll/js-must/blob/master/doc/API.md#mustactual-message-

Typescript complains that there is no signature for must that expects 2 arguments.

This commit fixes that.



