### PR TITLE
Correct typing by adding the optional custom error message that can be given

### DIFF
--- a/must.d.ts
+++ b/must.d.ts
@@ -72,7 +72,7 @@ interface Must {
 interface CallableMust extends Must {
     (): Must;
 }
-declare function must(expected: any): Must;
+declare function must(expected: any, customErrorMessage?: string): Must;
 declare namespace must {}
 
 export = must;


### PR DESCRIPTION
I get errors when using this library with TS when using a custom error message. This commit should fix the optional custom error message that can be given.